### PR TITLE
Allow special headers w/ arbitrary name casing

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::mem;
@@ -1139,6 +1140,17 @@ impl Builder {
     /// Default is false.
     pub fn http1_preserve_header_case(&mut self, val: bool) -> &mut Self {
         self.conn_builder.http1_preserve_header_case(val);
+        self
+    }
+
+    /// Allows passing a HashMap of headers that will be sent with
+    /// specified casing
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is None.
+    pub fn http1_special_headers(&mut self, val: Option<&'static HashMap<&'static str, &'static [u8]>>) -> &mut Self {
+        self.conn_builder.http1_special_headers(val);
         self
     }
 

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
@@ -61,6 +62,7 @@ where
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
                 title_case_headers: false,
+                special_headers: None,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: None,
@@ -107,6 +109,10 @@ where
 
     pub(crate) fn set_title_case_headers(&mut self) {
         self.state.title_case_headers = true;
+    }
+
+    pub(crate) fn set_special_headers(&mut self, val: Option<&'static HashMap<&'static str, &'static [u8]>>) {
+        self.state.special_headers = val;
     }
 
     pub(crate) fn set_preserve_header_case(&mut self) {
@@ -562,6 +568,7 @@ where
                 keep_alive: self.state.wants_keep_alive(),
                 req_method: &mut self.state.method,
                 title_case_headers: self.state.title_case_headers,
+                special_headers: self.state.special_headers,
             },
             buf,
         ) {
@@ -827,6 +834,7 @@ struct State {
     #[cfg(feature = "ffi")]
     preserve_header_order: bool,
     title_case_headers: bool,
+    special_headers: Option<&'static HashMap<&'static str, &'static [u8]>>,
     h09_responses: bool,
     /// If set, called with each 1xx informational response received for
     /// the current request. MUST be unset after a non-1xx response is

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 #[cfg(all(feature = "server", feature = "runtime"))]
 use std::{pin::Pin, time::Duration};
 
@@ -100,6 +101,7 @@ pub(crate) struct Encode<'a, T> {
     keep_alive: bool,
     req_method: &'a mut Option<Method>,
     title_case_headers: bool,
+    special_headers: Option<&'static HashMap<&'static str, &'static [u8]>>,
 }
 
 /// Extra flags that a request "wants", like expect-continue or upgrades.

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::mem::MaybeUninit;
 
@@ -1146,7 +1147,7 @@ impl Http1Transaction for Client {
         } else if msg.title_case_headers {
             write_headers_title_case(&msg.head.headers, dst);
         } else {
-            write_headers(&msg.head.headers, dst);
+            write_headers(&msg.head.headers, dst, msg.special_headers);
         }
 
         extend(dst, b"\r\n");
@@ -1441,9 +1442,17 @@ fn write_headers_title_case(headers: &HeaderMap, dst: &mut Vec<u8>) {
     }
 }
 
-fn write_headers(headers: &HeaderMap, dst: &mut Vec<u8>) {
+fn write_headers(headers: &HeaderMap, dst: &mut Vec<u8>, special_headers: Option<&HashMap<&'static str, &'static [u8]>>) {
     for (name, value) in headers {
-        extend(dst, name.as_str().as_bytes());
+        let name = if let Some(special_headers) = special_headers.as_ref() {
+            match special_headers.get(&name.as_str()) {
+                Some(x) => x,
+                None => name.as_str().as_bytes(),
+            }
+        } else {
+            name.as_str().as_bytes()
+        };
+        extend(dst, name);
         extend(dst, b": ");
         extend(dst, value.as_bytes());
         extend(dst, b"\r\n");
@@ -2404,6 +2413,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2435,6 +2445,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: false,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2469,6 +2480,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2493,6 +2505,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut Some(Method::CONNECT),
                 title_case_headers: false,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2522,6 +2535,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2556,6 +2570,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: false,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2590,6 +2605,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                special_headers: None,
             },
             &mut vec,
         )
@@ -2665,6 +2681,23 @@ mod tests {
 
         assert_eq!(dst, b"X-Empty: a\r\nX-EMPTY: b\r\n");
     }
+
+    #[test]
+    fn test_write_special_headers() {
+        let special_headers = HashMap::from([
+                    ("a-special-header", "A-spEciAl-hEaDER".as_bytes()),
+                ]);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::HeaderName::from_static("a-special-header"), "a".parse().unwrap());
+        headers.insert(http::header::HeaderName::from_static("not-a-special-header"), "a".parse().unwrap());
+
+        let mut dst = Vec::new();
+        super::write_headers(&headers, &mut dst, Some(&special_headers));
+
+        assert_eq!(dst, b"A-spEciAl-hEaDER: a\r\nnot-a-special-header: a\r\n");
+    }
+
 
     #[cfg(feature = "nightly")]
     use test::Bencher;
@@ -2806,6 +2839,7 @@ mod tests {
                     keep_alive: true,
                     req_method: &mut Some(Method::GET),
                     title_case_headers: false,
+                    special_headers: None,
                 },
                 &mut vec,
             )
@@ -2834,6 +2868,7 @@ mod tests {
                     keep_alive: true,
                     req_method: &mut Some(Method::GET),
                     title_case_headers: false,
+                    special_headers: None,
                 },
                 &mut vec,
             )


### PR DESCRIPTION
Allows adding headers with arbitrary casing
so that we can have headers that are all-caps,
all upper-case, or whatever else we want.

