### PR TITLE
Make HeaderCaseMap public

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::mem;
@@ -1140,17 +1139,6 @@ impl Builder {
     /// Default is false.
     pub fn http1_preserve_header_case(&mut self, val: bool) -> &mut Self {
         self.conn_builder.http1_preserve_header_case(val);
-        self
-    }
-
-    /// Allows passing a HashMap of headers that will be sent with
-    /// specified casing
-    ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
-    /// Default is None.
-    pub fn http1_special_headers(&mut self, val: Option<&'static HashMap<&'static str, &'static [u8]>>) -> &mut Self {
-        self.conn_builder.http1_special_headers(val);
         self
     }
 

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -54,7 +54,7 @@
 //! # }
 //! ```
 
-use std::{error::Error as StdError, collections::HashMap};
+use std::error::Error as StdError;
 use std::fmt;
 #[cfg(not(all(feature = "http1", feature = "http2")))]
 use std::marker::PhantomData;
@@ -156,7 +156,6 @@ pub struct Builder {
     h1_writev: Option<bool>,
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
-    h1_special_headers: Option<&'static HashMap<&'static str, &'static [u8]>>,
     #[cfg(feature = "ffi")]
     h1_preserve_header_order: bool,
     h1_read_buf_exact_size: Option<usize>,
@@ -572,7 +571,6 @@ impl Builder {
             version: Proto::Http1,
             #[cfg(not(feature = "http1"))]
             version: Proto::Http2,
-            h1_special_headers: None,
         }
     }
 
@@ -725,17 +723,6 @@ impl Builder {
     /// Default is false.
     pub fn http1_preserve_header_case(&mut self, enabled: bool) -> &mut Builder {
         self.h1_preserve_header_case = enabled;
-        self
-    }
-
-    /// Allows passing a HashMap of headers that will be sent with
-    /// specified casing
-    ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
-    /// Default is None.
-    pub fn http1_special_headers(&mut self, val: Option<&'static HashMap<&'static str, &'static [u8]>>) -> &mut Self {
-        self.h1_special_headers = val;
         self
     }
 
@@ -1001,8 +988,6 @@ impl Builder {
                     if opts.h1_preserve_header_case {
                         conn.set_preserve_header_case();
                     }
-
-                    conn.set_special_headers(opts.h1_special_headers);
 
                     #[cfg(feature = "ffi")]
                     if opts.h1_preserve_header_order {

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -95,7 +95,7 @@ impl fmt::Debug for Protocol {
 ///
 /// [`http1_preserve_header_case`]: /client/struct.Client.html#method.http1_preserve_header_case
 #[derive(Clone, Debug)]
-pub(crate) struct HeaderCaseMap(HeaderMap<Bytes>);
+pub struct HeaderCaseMap(HeaderMap<Bytes>);
 
 #[cfg(feature = "http1")]
 impl HeaderCaseMap {
@@ -128,6 +128,12 @@ impl HeaderCaseMap {
         N: IntoHeaderName,
     {
         self.0.append(name, orig);
+    }
+}
+
+impl From<HeaderMap<Bytes>> for HeaderCaseMap {
+    fn from(hdr_map: HeaderMap<Bytes>) -> Self {
+        Self(hdr_map)
     }
 }
 

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
@@ -62,7 +61,6 @@ where
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
                 title_case_headers: false,
-                special_headers: None,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: None,
@@ -109,10 +107,6 @@ where
 
     pub(crate) fn set_title_case_headers(&mut self) {
         self.state.title_case_headers = true;
-    }
-
-    pub(crate) fn set_special_headers(&mut self, val: Option<&'static HashMap<&'static str, &'static [u8]>>) {
-        self.state.special_headers = val;
     }
 
     pub(crate) fn set_preserve_header_case(&mut self) {
@@ -568,7 +562,6 @@ where
                 keep_alive: self.state.wants_keep_alive(),
                 req_method: &mut self.state.method,
                 title_case_headers: self.state.title_case_headers,
-                special_headers: self.state.special_headers,
             },
             buf,
         ) {
@@ -834,7 +827,6 @@ struct State {
     #[cfg(feature = "ffi")]
     preserve_header_order: bool,
     title_case_headers: bool,
-    special_headers: Option<&'static HashMap<&'static str, &'static [u8]>>,
     h09_responses: bool,
     /// If set, called with each 1xx informational response received for
     /// the current request. MUST be unset after a non-1xx response is

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 #[cfg(all(feature = "server", feature = "runtime"))]
 use std::{pin::Pin, time::Duration};
 
@@ -101,7 +100,6 @@ pub(crate) struct Encode<'a, T> {
     keep_alive: bool,
     req_method: &'a mut Option<Method>,
     title_case_headers: bool,
-    special_headers: Option<&'static HashMap<&'static str, &'static [u8]>>,
 }
 
 /// Extra flags that a request "wants", like expect-continue or upgrades.


### PR DESCRIPTION
This allows case-sensitive headers to be added
by simply adding a `HeaderCaseMap`-typed extension
to the hyper Request object.

Also undoes the other changes related to "special headers,"
which are no longer needed.